### PR TITLE
Updated Article Details widget to retrieve the correct document by ID

### DIFF
--- a/src/widgets/ArticleDetail/index.jsx
+++ b/src/widgets/ArticleDetail/index.jsx
@@ -16,13 +16,15 @@ export const ArticleDetailComponent = ({ id }) => {
   const {
     widgetRef,
     queryResult: { data: { content: articles = [] } = {} },
-  } = useSearchResults((query) => {
-    const equalFilter = new FilterEqual('id', id);
-    console.log(equalFilter.toJson());
-    query.getRequest().setSearchFilter(equalFilter);
-    return {
-      itemsPerPage: 1,
-    };
+  } = useSearchResults({
+      query: (query) => {
+        const equalFilter = new FilterEqual('id', id);
+        console.log(equalFilter.toJson());
+        query.getRequest().setSearchFilter(equalFilter);
+	  },
+	  state: {
+		itemsPerPage: 1,
+	  },
   });
   let mainArticle = { id: '', title: '' };
   if (articles.length > 0) {


### PR DESCRIPTION
The Article Details widget is updated with the new `useSearchResults` syntax and it now correctly pulls the requested document. Before this change it was showing the first document regardless of the passed document ID.