### PR TITLE
RFKUI-2459: Remove deprecated parameter

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,6 @@ function App() {
                 env={DISCOVER_CONFIG.env}
                 customerKey={DISCOVER_CONFIG.customerKey}
                 apiKey={DISCOVER_CONFIG.apiKey}
-                useToken
                 publicSuffix={true}
               >
                 <SEOWidget rfkId={'search_seo'} />


### PR DESCRIPTION
## Description

Removed deprecated parameter (`useToken`) since it is not used by the SDK anymore.
